### PR TITLE
解像度が高い画像の対応

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "com.example.photoapp"
-        minSdkVersion 15
+        minSdkVersion 19
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
@@ -28,4 +28,7 @@ dependencies {
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     implementation 'com.android.support:gridlayout-v7:28.0.0'
     implementation 'com.android.support:recyclerview-v7:28.0.0'
+    implementation 'com.github.bumptech.glide:glide:4.9.0'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.9.0'
+    implementation group: 'commons-io', name: 'commons-io', version: '2.6'
 }

--- a/app/src/main/java/com/example/photoapp/ImageViewActivity.java
+++ b/app/src/main/java/com/example/photoapp/ImageViewActivity.java
@@ -11,6 +11,11 @@ import android.view.View;
 import android.view.Window;
 import android.widget.Button;
 import android.widget.ImageView;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import org.apache.commons.io.IOUtils;
 
 public class ImageViewActivity extends Activity {
     private float scale = 1f;
@@ -23,9 +28,19 @@ public class ImageViewActivity extends Activity {
         requestWindowFeature(Window.FEATURE_NO_TITLE);
         setContentView(R.layout.activity_image_view);
 
-        Post post = (Post)getIntent().getSerializableExtra("Post");
-        Bitmap bmp = BitmapFactory.decodeByteArray(post.imageData, 0, post.imageData.length);
+        //画像のバイト配列をキャッシュファイルから読み込む
+        byte[] jpgImage = null;
+        final File f = new File(getCacheDir(), "cache.jpg");
+        try (FileInputStream fis = new FileInputStream(f)){
+            jpgImage = IOUtils.toByteArray(fis);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
 
+        //Post post = (Post)getIntent().getSerializableExtra("Post");
+        Bitmap bmp = BitmapFactory.decodeByteArray(jpgImage, 0, jpgImage.length);
+
+        //mbpをセットして表示
         final ImageView imageView = findViewById(R.id.image_view);
         imageView.setImageBitmap(bmp);
 
@@ -60,7 +75,4 @@ public class ImageViewActivity extends Activity {
         detector.onTouchEvent(event);
         return super.onTouchEvent(event);
     }
-
-
-
 }

--- a/app/src/main/java/com/example/photoapp/ImageViewActivity.java
+++ b/app/src/main/java/com/example/photoapp/ImageViewActivity.java
@@ -1,23 +1,24 @@
 package com.example.photoapp;
 
-import android.app.Activity;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.Bundle;
+import android.support.v7.widget.Toolbar;
+import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
-import android.view.View;
 import android.view.Window;
-import android.widget.Button;
 import android.widget.ImageView;
+import android.support.v7.app.AppCompatActivity;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 
 import org.apache.commons.io.IOUtils;
 
-public class ImageViewActivity extends Activity {
+public class ImageViewActivity extends AppCompatActivity {
     private float scale = 1f;
     private ScaleGestureDetector detector;
 
@@ -28,6 +29,15 @@ public class ImageViewActivity extends Activity {
         requestWindowFeature(Window.FEATURE_NO_TITLE);
         setContentView(R.layout.activity_image_view);
 
+        Toolbar toolbar = findViewById(R.id.tool_bar);
+        setSupportActionBar(toolbar);
+
+        //戻るボタンを表示
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        getSupportActionBar().setHomeButtonEnabled(true);
+
+        getSupportActionBar().setDisplayShowTitleEnabled(false);
+
         //画像のバイト配列をキャッシュファイルから読み込む
         byte[] jpgImage = null;
         final File f = new File(getCacheDir(), "cache.jpg");
@@ -37,7 +47,6 @@ public class ImageViewActivity extends Activity {
             e.printStackTrace();
         }
 
-        //Post post = (Post)getIntent().getSerializableExtra("Post");
         Bitmap bmp = BitmapFactory.decodeByteArray(jpgImage, 0, jpgImage.length);
 
         //mbpをセットして表示
@@ -56,23 +65,32 @@ public class ImageViewActivity extends Activity {
         }
 
         detector = new ScaleGestureDetector(this,new ScaleListener());
-
-        Button button = findViewById(R.id.exitButton);
-        button.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                // EXITボタンをタップするともとの画面に戻る
-                Intent intent = new Intent();
-                setResult(RESULT_OK, intent);
-                finish();
-            }
-        });
-
     }
 
     public boolean onTouchEvent(MotionEvent event) {
         //re-route the Touch Events to the ScaleListener class
         detector.onTouchEvent(event);
         return super.onTouchEvent(event);
+    }
+
+    //ツールバーの各種アイコンが押されたときに呼ばれる(今は戻るボタンだけ)
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        int id = item.getItemId();
+
+        boolean result = true;
+
+        switch (id) {
+            case android.R.id.home:
+                // 矢印ボタンを押すともとの画面に戻る
+                Intent intent = new Intent();
+                setResult(RESULT_OK, intent);
+                finish();
+                break;
+            default:
+                result = super.onOptionsItemSelected(item);
+        }
+
+        return result;
     }
 }

--- a/app/src/main/java/com/example/photoapp/MainActivity.java
+++ b/app/src/main/java/com/example/photoapp/MainActivity.java
@@ -11,8 +11,8 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.widget.Button;
-
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.FileDescriptor;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -50,7 +50,6 @@ public class MainActivity extends AppCompatActivity {
             }
         });
     }
-
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent resultData) {

--- a/app/src/main/java/com/example/photoapp/timelineViewAdapter.java
+++ b/app/src/main/java/com/example/photoapp/timelineViewAdapter.java
@@ -11,7 +11,11 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 
-import java.io.ByteArrayOutputStream;
+import com.bumptech.glide.Glide;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.List;
 
 public class timelineViewAdapter extends RecyclerView.Adapter<timelineViewAdapter.ViewHolder> {
@@ -49,13 +53,23 @@ public class timelineViewAdapter extends RecyclerView.Adapter<timelineViewAdapte
         //byte(jpeg)→Bitmapに変換
         Bitmap bmp = BitmapFactory.decodeByteArray(imageData, 0, imageData.length);
 
-        holder.imageView.setImageBitmap(bmp);
+        //RecycleビューにBitmapをセット
+        Glide.with(context).load(bmp).into(holder.imageView);
+
+        //画像のバイト配列をキャッシュファイルに保存
+        File f = new File(context.getCacheDir(), "cache.jpg");
+        try (FileOutputStream fos = new FileOutputStream(f)){
+            fos.write(posts.get(position).imageData);
+        } catch (IOException e){
+            e.printStackTrace();
+        }
+
         holder.imageView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 //タッチしたpostインスタンスをimageViewActivityに渡す
                 Intent intent = new Intent(context, ImageViewActivity.class);
-                intent.putExtra("Post", posts.get(position));
+                //intent.putExtra("Post", posts.get(position));
                 activity.startActivityForResult(intent, RESULTCODE);
             }
         });

--- a/app/src/main/java/com/example/photoapp/timelineViewAdapter.java
+++ b/app/src/main/java/com/example/photoapp/timelineViewAdapter.java
@@ -6,13 +6,12 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.support.v7.widget.RecyclerView;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
-
 import com.bumptech.glide.Glide;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -56,17 +55,19 @@ public class timelineViewAdapter extends RecyclerView.Adapter<timelineViewAdapte
         //RecycleビューにBitmapをセット
         Glide.with(context).load(bmp).into(holder.imageView);
 
-        //画像のバイト配列をキャッシュファイルに保存
-        File f = new File(context.getCacheDir(), "cache.jpg");
-        try (FileOutputStream fos = new FileOutputStream(f)){
-            fos.write(posts.get(position).imageData);
-        } catch (IOException e){
-            e.printStackTrace();
-        }
 
         holder.imageView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
+
+                //画像のバイト配列をキャッシュファイルに保存
+                File f = new File(context.getCacheDir(), "cache.jpg");
+                try (FileOutputStream fos = new FileOutputStream(f)){
+                    fos.write(posts.get(holder.getAdapterPosition()).imageData);
+                } catch (IOException e){
+                    e.printStackTrace();
+                }
+
                 //タッチしたpostインスタンスをimageViewActivityに渡す
                 Intent intent = new Intent(context, ImageViewActivity.class);
                 //intent.putExtra("Post", posts.get(position));

--- a/app/src/main/res/layout/activity_image_view.xml
+++ b/app/src/main/res/layout/activity_image_view.xml
@@ -8,36 +8,27 @@
     android:background="#000000"
     tools:layout_editor_absoluteY="81dp">
 
+
     <ImageView
         android:id="@+id/image_view"
-        android:layout_width="391dp"
-        android:layout_height="254dp"
-        android:layout_marginTop="172dp"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
         android:adjustViewBounds="true"
         android:contentDescription="@string/image_view"
         android:scaleType="fitCenter"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-
-    <Button
-        android:id="@+id/exitButton"
-        android:layout_width="wrap_content"
+    <android.support.v7.widget.Toolbar
+        android:id="@+id/tool_bar"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="161dp"
-        android:layout_marginLeft="161dp"
-        android:layout_marginTop="76dp"
-        android:layout_marginEnd="162dp"
-        android:layout_marginRight="162dp"
-        android:layout_marginBottom="8dp"
-        android:text="@string/exit"
-        android:textSize="24sp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/image_view" />
+        android:background="#000000"
+        android:minHeight="?attr/actionBarSize"
+        android:theme="?attr/actionBarTheme"
+        app:layout_constraintTop_toTopOf="parent" />
 
 
 </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
## 変更点
- 解像度が高い画像も投稿できるようにした
- 解像度が高い画像をタッチして拡大できるようにした
- ImageViewActivityのデザインを修正
  - 画像が中央画面いっぱいに表示されるようにする
  - Exitボタンの廃止
  - 戻るボタンを追加

## TransactionTooLargeExceptionの対策
- Intent同士でデータをやり取りする際に、500kbぐらいを超えるとアプリが落ちる
  - Intent間ではデータを送らずにキャッシュファイルにバイト配列を保存し、Intent先で読み込むようにする

## ImageViewActivityの戻るボタンについて
- Activityを拡張したAppCompatActivityに便利な関数群があったのでそれを使った。
 - `getSupportActionBar().setDisplayHomeAsUpEnabled(true);`で戻るボタンを表示してる
        